### PR TITLE
fix(import): Update import statement for blacklist module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import blacklist from '@ip1sms/disposable-phone-numbers';
+import blacklist from '@ip1sms/disposable-phone-numbers' with { type: "json" };
 
 /**
  * Expose `isDisposablePhoneNumber`.


### PR DESCRIPTION
Node.js versions 22+ (and strictly v24+) now enforce Import Attributes for JSON modules in ESM.
Without the 'type: json' attribute, the application crashes with ERR_IMPORT_ATTRIBUTE_MISSING.

This commit updates the import statement for 'number-list.json' to include the required syntax:
`import ... with { type: "json" }`.